### PR TITLE
Fix typo in reloadData()

### DIFF
--- a/JExpandableTableView/Classes/JExpandableTableView.swift
+++ b/JExpandableTableView/Classes/JExpandableTableView.swift
@@ -165,7 +165,7 @@ public class JExpandableTableView: UIView , UITableViewDataSource, UITableViewDe
         tableview.rowHeight = height
     }
     
-    open func realoadData() -> Void {
+    open func reloadData() -> Void {
         self.tableview.reloadData()
     }
     


### PR DESCRIPTION
Method named **realoadData** is obviously a result of a typo. It should be called **reloadData**, just like it's counterpart in UITableView.